### PR TITLE
move moment and full calendar above inline scripts on calendar page

### DIFF
--- a/CRM/Eventcalendar/Page/ShowEvents.php
+++ b/CRM/Eventcalendar/Page/ShowEvents.php
@@ -38,8 +38,8 @@ require_once 'CRM/Core/Page.php';
 class CRM_Eventcalendar_Page_ShowEvents extends CRM_Core_Page {
 
   function run() {
-    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/moment.js',5);
-    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/fullcalendar.js',10);
+    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/moment.js', 5, 'page-header');
+    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/fullcalendar.js', 10, 'page-header');
     CRM_Core_Resources::singleton()->addStyleFile('com.osseed.eventcalendar', 'css/civicrm_events.css');
     CRM_Core_Resources::singleton()->addStyleFile('com.osseed.eventcalendar', 'css/fullcalendar.css');
 

--- a/CRM/Eventcalendar/Page/ShowEvents.php
+++ b/CRM/Eventcalendar/Page/ShowEvents.php
@@ -38,8 +38,9 @@ require_once 'CRM/Core/Page.php';
 class CRM_Eventcalendar_Page_ShowEvents extends CRM_Core_Page {
 
   function run() {
-    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/moment.js', 5, 'page-header');
-    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/fullcalendar.js', 10, 'page-header');
+    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/moment.js', 5, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/fullcalendar.js', 10, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('com.osseed.eventcalendar', 'js/rendereventcalendar.js', 10, 'html-header');
     CRM_Core_Resources::singleton()->addStyleFile('com.osseed.eventcalendar', 'css/civicrm_events.css');
     CRM_Core_Resources::singleton()->addStyleFile('com.osseed.eventcalendar', 'css/fullcalendar.css');
 

--- a/README.txt
+++ b/README.txt
@@ -11,10 +11,10 @@ If you are new to CiviCRM Extension you can get help about extension from
 
 http://wiki.civicrm.org/confluence/display/CRMDOC42/Extensions
 
-Library
----------------
-Extension uses the fullcalendar library.
-Add the fullcalendar library https://github.com/fullcalendar/fullcalendar/releases/tag/v1.6.7
+Requires
+--------
+Extension required https://www.drupal.org/project/jquery_update module for installation with Drupal.
+
 
 Usage
 ---------------

--- a/css/civicrm_events.css
+++ b/css/civicrm_events.css
@@ -1,4 +1,4 @@
-.fc-event-time, .fc-event-title {
+.fc-time, .fc-title {
  color:#fff;
 }
 

--- a/info.xml
+++ b/info.xml
@@ -12,8 +12,8 @@
 	<url desc="Main Extension Page">https://github.com/osseed/com.osseed.eventcalendar</url>
 	<url desc="Documentation">https://raw.github.com/osseed/com.osseed.eventcalendar/master/README.txt</url>
 </urls>
-  <releaseDate>2018-08-01</releaseDate>
-  <version>2.3</version>
+  <releaseDate>2019-08-23</releaseDate>
+  <version>2.4</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/js/rendereventcalendar.js
+++ b/js/rendereventcalendar.js
@@ -1,0 +1,30 @@
+if (typeof(jQuery) != 'function')
+  var jQuery = cj;
+
+cj(function(){
+  buildCalendar();
+});
+
+function buildCalendar() {
+
+  var events_data = cj('#calendar').data('events');
+  var showTime = events_data.timeDisplay;
+
+  cj('#calendar').fullCalendar({
+    eventSources: [
+      { events: events_data.events,}
+    ],
+    displayEventTime: showTime ? 1 : 0,
+    timeFormat: 'h(:mm)A',
+
+    eventRender: function eventRender( event, element, view ) {
+      if(event.eventType && events_data.isfilter == "1" ) {
+        return ['all', event.eventType].indexOf(cj('#event_selector').val()) >= 0
+      }
+    }
+  });
+
+  cj('#event_selector').on('change', function(){
+    cj('#calendar').fullCalendar('rerenderEvents');
+  })
+}

--- a/templates/CRM/Eventcalendar/Page/ShowEvents.tpl
+++ b/templates/CRM/Eventcalendar/Page/ShowEvents.tpl
@@ -6,37 +6,4 @@
     {/foreach}
   </select>
 {/if}
-<div id="calendar"></div>
-
-{literal}
-<script type="text/javascript">
- if (typeof(jQuery) != 'function')
-     var jQuery = cj;
- cj( function( ) {
-    buildCalendar( );
-  });
- function buildCalendar( ) {
-   var events_data = {/literal}{$civicrm_events}{literal};
-   var jsonStr = JSON.stringify(events_data);
-   var showTime = events_data.timeDisplay;
-
-   cj('#calendar').fullCalendar({
-    eventSources: [
-      { events: events_data.events,}
-    ],
-    displayEventTime: showTime ? 1 : 0,
-    timeFormat: 'h(:mm)A',
-
-    eventRender: function eventRender( event, element, view ) {
-      if(event.eventType && events_data.isfilter == "1" ) {
-        return ['all', event.eventType].indexOf(cj('#event_selector').val()) >= 0
-      }
-    }
-   });
-
-   cj('#event_selector').on('change', function(){
-      cj('#calendar').fullCalendar('rerenderEvents');
-   })
- }
-</script>
-{/literal}
+<div id="calendar" data-events="{$civicrm_events|escape}"></div>


### PR DESCRIPTION
moment.js and fullcalendar.js were loading below the inline javascrpt in tempalte/CRM/Eventcalendar/Page/ShowEvents.tpl causing a a cj.fullcalendar is not defined error in Wordpress