### PR TITLE
BASW-643: Fix calendar for dashlet on dashboard and configure text colour for events calendar events

### DIFF
--- a/CRM/Eventcalendar/Page/ShowEvents.php
+++ b/CRM/Eventcalendar/Page/ShowEvents.php
@@ -111,6 +111,7 @@ class CRM_Eventcalendar_Page_ShowEvents extends CRM_Core_Page {
         $eventData[$k] = $dao->$k;
         if(!empty($eventTypes)) {
           $eventData['backgroundColor'] = "#{$eventTypes[$dao->event_type]}";
+          $eventData['textColor'] = $this->_getContrastTextColor($eventData['backgroundColor']);
           $eventData['eventType'] = $civieventTypesList[$dao->event_type];
         }
       }
@@ -172,5 +173,47 @@ class CRM_Eventcalendar_Page_ShowEvents extends CRM_Core_Page {
     ));*/
 
     return $settings;
+  }
+
+  /*
+   * Return contrast color on the basis the hex color passed
+   *
+   * Referred from https://stackoverflow.com/questions/1331591
+   */
+  function _getContrastTextColor($hexColor){
+    // hexColor RGB
+    $R1 = hexdec(substr($hexColor, 1, 2));
+    $G1 = hexdec(substr($hexColor, 3, 2));
+    $B1 = hexdec(substr($hexColor, 5, 2));
+
+    // Black RGB
+    $blackColor = "#000000";
+    $R2BlackColor = hexdec(substr($blackColor, 1, 2));
+    $G2BlackColor = hexdec(substr($blackColor, 3, 2));
+    $B2BlackColor = hexdec(substr($blackColor, 5, 2));
+
+     // Calc contrast ratio
+     $L1 = 0.2126 * pow($R1 / 255, 2.2) +
+           0.7152 * pow($G1 / 255, 2.2) +
+           0.0722 * pow($B1 / 255, 2.2);
+
+    $L2 = 0.2126 * pow($R2BlackColor / 255, 2.2) +
+          0.7152 * pow($G2BlackColor / 255, 2.2) +
+          0.0722 * pow($B2BlackColor / 255, 2.2);
+
+    $contrastRatio = 0;
+    if ($L1 > $L2) {
+        $contrastRatio = (int)(($L1 + 0.05) / ($L2 + 0.05));
+    } else {
+        $contrastRatio = (int)(($L2 + 0.05) / ($L1 + 0.05));
+    }
+
+    // If contrast is more than 5, return black color
+    if ($contrastRatio > 5) {
+        return '#000000';
+    } else {
+        // if not, return white color.
+        return '#FFFFFF';
+    }
   }
 }

--- a/css/civicrm_events.css
+++ b/css/civicrm_events.css
@@ -1,7 +1,3 @@
-.fc-time, .fc-title {
- color:#fff;
-}
-
 .event-info-details a{
 	border-bottom: 1px solid #ddd;
   display: block;

--- a/templates/CRM/Eventcalendar/Page/ShowEvents.tpl
+++ b/templates/CRM/Eventcalendar/Page/ShowEvents.tpl
@@ -16,17 +16,46 @@
   else {
     var cj = jQuery;
   }
+
   cj( function( ) {
-    buildCalendar( );
+    checkFullCalendarLIbrary()
+    .then(function() {
+      buildCalendar();
+    })
+    .catch(function() {
+      alert('Error loading calendar, try refreshing...');
+    });
   });
 
- function buildCalendar( ) {
-   var events_data = {/literal}{$civicrm_events}{literal};
-   var jsonStr = JSON.stringify(events_data);
-   var showTime = events_data.timeDisplay;
-   var weekStartDay = {/literal}{$weekBeginDay}{literal};
+/*
+ * Checks if full calendar API is ready.
+ *
+ * @returns {Promise}
+ *  if library is available or not.
+ */
+function checkFullCalendarLIbrary() {
+  return new Promise((resolve, reject) => {
+    if(cj.fullCalendar) {
+      resolve();
+    } else {
+      cj(document).ajaxComplete(function() {
+        if(cj.fullCalendar) {
+          resolve();
+        } else {
+          reject();
+        }
+      });
+    }
+  });
+}
 
-   cj('#calendar').fullCalendar({
+function buildCalendar( ) {
+  var events_data = {/literal}{$civicrm_events}{literal};
+  var jsonStr = JSON.stringify(events_data);
+  var showTime = events_data.timeDisplay;
+  var weekStartDay = {/literal}{$weekBeginDay}{literal};
+
+  cj('#calendar').fullCalendar({
     eventSources: [
       { events: events_data.events,}
     ],


### PR DESCRIPTION
## Overview 
This PR fixes
* Text color on the calendar events. currently all calendar events have text color of white(no matter of their background color) and this creates a contrasting UX problem. The text become very unclear to read if background color of events on the calendar are too light)

* Fix the calendar on events dashlet on dashboard page. Initially, the events dashlet on dashboard doesn't show events. Now we fix this.

### Before - text color
<img width="1568" alt="Screenshot 2020-05-27 at 9 27 25 PM" src="https://user-images.githubusercontent.com/3340537/83114213-53f97100-a0e6-11ea-9544-557c90200687.png">

### After - text color
<img width="1433" alt="Screenshot 2020-05-27 at 9 26 36 PM" src="https://user-images.githubusercontent.com/3340537/83114250-5e1b6f80-a0e6-11ea-9c3d-92a0116355e0.png">

### Before - events calendar on dashboard
<img width="1240" alt="Screenshot 2020-05-28 at 12 33 27 PM" src="https://user-images.githubusercontent.com/3340537/83114297-6d022200-a0e6-11ea-8184-6916aa119fb1.png">

### After - events calendar on dashboard
![ezgif com-optimize](https://user-images.githubusercontent.com/3340537/83114345-7ab7a780-a0e6-11ea-9610-4bd0d2ed68df.gif)

## Technical Details

### Text color.
We used a PHP function which will return contrasting color on the basis of the hex code. The solution was encouraged from here - https://stackoverflow.com/questions/1331591
This function will return white color hex code if bg is too dark and returns white color if bg is too light.
  This function is then used to provide `textColor` to the full calendar JS library events items( see `ShowEvents.php`). To make it work we had to disable the css which sets the text color of the full calendar events to `white` . See (`_events.css `)

### Events on Dashlet
The issue with this is that the full calendar library was not attached on the page at the time of load but was attached by the AJAX (XHR) call. 
<img width="1677" alt="Screenshot 2020-05-28 at 12 32 10 PM" src="https://user-images.githubusercontent.com/3340537/83114905-3bd62180-a0e7-11ea-8de9-1d53fe48b40f.png">
In this way when full calendar template (compiled HTML) was added via AJAX there is a race condition which happens in which `buildCalendar` which calls the full calendar API function gets initiated before the related full calendar library is even finished loading. And hence `full-calendar` becomes undefined.
<img width="1680" alt="Screenshot 2020-05-28 at 1 34 13 PM" src="https://user-images.githubusercontent.com/3340537/83115438-fa924180-a0e7-11ea-8e3d-4cccbad7e8c0.png">
<img width="485" alt="Screenshot 2020-05-28 at 1 34 22 PM" src="https://user-images.githubusercontent.com/3340537/83115496-0f6ed500-a0e8-11ea-8bda-59d26985c8cb.png">

To fix this, we created a promise which will check if `fullCalendar` function is available under jQuery on load or not and if it doesn't then it waits for the `ajaxComplete` event (which will make sure that if the full calendar library is called through AJAX gets loaded on the page) and then calls the `buildCalendar` function, making it execute w/o error.

