### PR TITLE
add functionality to use Search Kit to filter event calendar settings

### DIFF
--- a/CRM/EventCalendar/Form/EventCalendarSettings.php
+++ b/CRM/EventCalendar/Form/EventCalendarSettings.php
@@ -56,6 +56,21 @@ class CRM_EventCalendar_Form_EventCalendarSettings extends CRM_Core_Form {
       $descriptions['recurring_event'] = ts('Show only recurring events.');
       $this->add('advcheckbox', 'enrollment_status', ts('Show enrollment status'));
       $descriptions['enrollment_status'] = ts('Show enrollment status on calendar event.');
+      $searchKitEnabled = \Civi\Api4\Extension::get(FALSE)
+        ->addWhere('file', '=', 'search_kit')
+        ->addWhere('status', '=', 'installed')
+        ->execute()
+        ->count();
+      if ($searchKitEnabled) {
+        $this->addEntityRef('saved_search_id', ts('Search Kit saved search'), [
+          'entity' => 'SavedSearch',
+          'api' => [
+            'params' => ['api_entity' => 'Event'],
+          ],
+          'select' => ['minimumInputLength' => 0],
+        ]);
+        $descriptions['saved_search_id'] = ts('Optionally filter only to events found in this saved search.');
+      }
 
       $eventTypes = CRM_Event_PseudoConstant::eventType();
       foreach ($eventTypes as $id => $type) {
@@ -94,9 +109,9 @@ class CRM_EventCalendar_Form_EventCalendarSettings extends CRM_Core_Form {
     }
 
     if ($submitted['action'] == 'add') {
-      $sql = "INSERT INTO civicrm_event_calendar(calendar_title, show_past_events, show_end_date, show_public_events, events_by_month, event_timings, events_from_month, event_type_filters, week_begins_from_day, recurring_event, enrollment_status)
+      $sql = "INSERT INTO civicrm_event_calendar(calendar_title, show_past_events, show_end_date, show_public_events, events_by_month, event_timings, events_from_month, event_type_filters, week_begins_from_day, recurring_event, enrollment_status, saved_search_id)
        VALUES ('{$submitted['calendar_title']}', {$submitted['show_past_events']}, {$submitted['show_end_date']}, {$submitted['show_public_events']}, {$submitted['events_by_month']}, {$submitted['event_timings']}, {$submitted['events_from_month']}, {$submitted['event_type_filters']},
-          {$submitted['week_begins_from_day']}, {$submitted['recurring_event']}, {$submitted['enrollment_status']});";
+          {$submitted['week_begins_from_day']}, {$submitted['recurring_event']}, {$submitted['enrollment_status']}, {$submitted['saved_search_id']});";
       $dao = CRM_Core_DAO::executeQuery($sql);
       $cfId = CRM_Core_DAO::singleValueQuery('SELECT LAST_INSERT_ID()');
       foreach ($submitted as $key => $value) {
@@ -114,7 +129,7 @@ class CRM_EventCalendar_Form_EventCalendarSettings extends CRM_Core_Form {
     if ($submitted['action'] == 'update') {
       $sql = "UPDATE civicrm_event_calendar
        SET calendar_title = '{$submitted['calendar_title']}', show_past_events = {$submitted['show_past_events']}, show_end_date = {$submitted['show_end_date']}, show_public_events = {$submitted['show_public_events']}, events_by_month = {$submitted['events_by_month']}, event_timings = {$submitted['event_timings']}, events_from_month = {$submitted['events_from_month']},
-        event_type_filters = {$submitted['event_type_filters']}, week_begins_from_day = {$submitted['week_begins_from_day']}, recurring_event = {$submitted['recurring_event']},  enrollment_status = {$submitted['enrollment_status']}
+        event_type_filters = {$submitted['event_type_filters']}, week_begins_from_day = {$submitted['week_begins_from_day']}, recurring_event = {$submitted['recurring_event']},  enrollment_status = {$submitted['enrollment_status']}, saved_search_id = {$submitted['saved_search_id']}
        WHERE `id` = {$submitted['calendar_id']};";
       $dao = CRM_Core_DAO::executeQuery($sql);
       //delete current event type records to update with new ones

--- a/CRM/EventCalendar/Page/ShowEvents.php
+++ b/CRM/EventCalendar/Page/ShowEvents.php
@@ -106,6 +106,13 @@ class CRM_EventCalendar_Page_ShowEvents extends CRM_Core_Page {
       ";
     }
 
+    // Filter Events based on Saved Search
+    if (!empty($settings['saved_search_id'])) {
+      $eventIds = $this->getSavedSearchEvents($settings['saved_search_id']);
+      $ids = implode(',', $eventIds);
+      $whereCondition .= " AND id IN (" . $ids . ")";
+    }
+
     $query .= $whereCondition;
     $events['events'] = array();
 
@@ -170,6 +177,7 @@ class CRM_EventCalendar_Page_ShowEvents extends CRM_Core_Page {
     //Send Events array to calendar.
     $this->assign('civicrm_events', json_encode($events));
     parent::run();
+
   }
 
   /**
@@ -194,6 +202,7 @@ class CRM_EventCalendar_Page_ShowEvents extends CRM_Core_Page {
          $settings['week_begins_from_day'] = $dao->week_begins_from_day;
          $settings['recurring_event'] = $dao->recurring_event;
          $settings['enrollment_status'] = $dao->enrollment_status;
+         $settings['saved_search_id'] = $dao->saved_search_id;
        }
 
        $sql = "SELECT * FROM civicrm_event_calendar_event_type WHERE `event_calendar_id` = {$calendarId};";
@@ -260,4 +269,19 @@ class CRM_EventCalendar_Page_ShowEvents extends CRM_Core_Page {
       return '#FFFFFF';
     }
   }
+
+  private function getSavedSearchEvents($searchId) : array {
+    $savedSearch = \Civi\Api4\SavedSearch::get()
+      ->addWhere('id', '=', $searchId)
+      ->execute()
+      ->first();
+    if (!$savedSearch) {
+      return [];
+    }
+    $savedSearch['api_params']['select'] = [0 => 'id'];
+    $searchedEvents = (array) civicrm_api4($savedSearch['api_entity'], 'get', $savedSearch['api_params']);
+    $eventIds = array_column($searchedEvents, 'id');
+    return $eventIds;
+  }
+
 }

--- a/CRM/EventCalendar/Upgrader.php
+++ b/CRM/EventCalendar/Upgrader.php
@@ -53,6 +53,25 @@ class CRM_EventCalendar_Upgrader extends CRM_EventCalendar_Upgrader_Base {
     CRM_Core_Session::setStatus(ts('You may need to clear caches and reset paths as some menu items have changed'), ts('Success'), 'success');
     return TRUE;
   }
+
+  public function upgrade_1002() {
+    $config = CRM_Core_Config::singleton();
+    $dbName = DB::connect($config->dsn)->_db;
+
+    // Add search_id column to civicrm_event_calendar table.
+    $sql = "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = %1 AND TABLE_NAME = 'civicrm_event_calendar' AND COLUMN_NAME = 'saved_search_id'";
+    $dao = CRM_Core_DAO::executeQuery($sql, [1 => [$dbName, 'String']]);
+    $saved_search_id_column_exists = $dao->N == 0 ? FALSE : TRUE;
+    if (!$saved_search_id_column_exists) {
+      $this->ctx->log->info('Applying civicrm_event_calendar update 1002.  Adding saved_search_id to civicrm_event_calendar table.');
+      CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_event_calendar ADD COLUMN `saved_search_id` int(11) COMMENT "Filter results by this saved search"');
+    }
+    else {
+      $this->ctx->log->info('Skipped civicrm_event_calendar update 1002.  Column saved_search_id already present on civicrm_event_calendar table.');
+    }
+    return TRUE;
+  }
+
   /**
    * Example: Run an external SQL script when the module is installed.
    *

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -64,7 +64,8 @@ CREATE TABLE `civicrm_event_calendar` (
      `event_type_filters` tinyint    COMMENT 'Whether to show event type filters',
      `week_begins_from_day` tinyint    COMMENT 'Show week begins from day',
      `recurring_event`  tinyint   COMMENT 'Show recurring events',
-     `enrollment_status` tinyint   COMMENT 'Show enrollment status'
+     `enrollment_status` tinyint   COMMENT 'Show enrollment status',
+     `saved_search_id` int(11) COMMENT 'Filter results by this saved search'
 ,
         PRIMARY KEY (`id`)
 


### PR DESCRIPTION
This allows a user to filter an event calendar by creating a Search Kit search with "Events" as the base entity.  Only events that are in the Search Kit search will appear on the calendar.  Search Kit ships with core. If Search Kit isn't enabled, the setting is ignored.

I know this doesn't have documentation and obviously needs some.  If you agree with this improvement, let us know and we'll add documentation to the README.