### PR TITLE
rename wordpress-event-calendar to avoid name collision

### DIFF
--- a/wordpress/osseed-wordpress-event-calendar/osseed-wordpress-event-calendar.php
+++ b/wordpress/osseed-wordpress-event-calendar/osseed-wordpress-event-calendar.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-Plugin Name: Wordpress Event Calendar
+Plugin Name: OSSeed Wordpress Event Calendar
 Plugin URI:
 Description: CiviCRM Calendar Plugin
 Author: OSSeed


### PR DESCRIPTION
Upon installing the WordPress plugin, I started receiving messages in `wp-cli` to the effect of `wordpress-event-calendar version higher than expected`.

There's a WP plugin that already uses the name `wordpress-event-calendar` and the WP plugin update code assumes this plugin is that plugin.

This PR renames the plugin to avoid the name collision.