### PR TITLE
Add recurring_event and enrollment_status columns if missing

### DIFF
--- a/CRM/EventCalendar/Upgrader.php
+++ b/CRM/EventCalendar/Upgrader.php
@@ -74,6 +74,23 @@ class CRM_EventCalendar_Upgrader extends CRM_EventCalendar_Upgrader_Base {
     return TRUE;
   }
 
+   /**
+   * Add recurring_event and enrollment_status columns to the civicrm_event_calendar table if missing.
+   */
+  public function upgrade_1003() {
+    $this->ctx->log->info('Check to see if recurring_event and enrollment_status columns are present on the civicrm_event_calendar table.');
+    if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_event_calendar', 'recurring_event')) {
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_event_calendar ADD COLUMN recurring_event tinyint DEFAULT NULL COMMENT 'Show recurring events'");
+    }
+    if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_event_calendar', 'enrollment_status')) {
+      CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_event_calendar ADD COLUMN enrollment_status tinyint DEFAULT NULL COMMENT 'Show enrollment status'");
+    }
+    else {
+      $this->ctx->log->info('Skipped civicrm_event_calendar update 1003. Columns already present on the civicrm_event_calendar table.');
+    }
+    return TRUE;
+  }
+
   /**
    * Example: Run an external SQL script when the module is installed.
    *


### PR DESCRIPTION
### Overview
Adding a new calendar may result in a DB error, caused by missing columns, depending on when the user's instance of this extension was upgraded.

-------------------------------------------------

### Before
Depending on when this extension is installed, users may run into a fatal error when creating a calendar because the columns `recurring_event` and `enrollment_status ` are missing from the database:
```
DebugInfo   INSERT INTO civicrm_event_calendar(calendar_title, show_past_events, show_end_date, show_public_events, events_by_month, event_timings, events_from_month, event_type_filters, week_begins_from_day, recurring_event, enrollment_status, saved_search_id) VALUES ('Tours', 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0); 
[nativecode=1054 ** Unknown column 
- DB_Error: DB Error: no such field in unknown on line unknown
```
These missing columns were addressed by [PR #92](https://github.com/osseed/com.osseed.eventcalendar/commit/81d0716331fcad3a7fa9976c8f971c292bdbdaf4), however, it didn't account for users who may have already run the `upgrade_1001` step, in which case the fix would not be applied to their instance of the extension.

-------------------------------------------------

### After
This PR adds a separate upgrade step to ensure that if the `recurring_event` and `enrollment_status` columns are missing, that they are added to the `civicrm_event_calendar` table.