### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/CRM/EventCalendar/BAO/EventCalendar.php
+++ b/CRM/EventCalendar/BAO/EventCalendar.php
@@ -3,22 +3,5 @@ use CRM_EventCalendar_ExtensionUtil as E;
 
 class CRM_EventCalendar_BAO_EventCalendar extends CRM_EventCalendar_DAO_EventCalendar {
 
-  /**
-   * Create a new EventCalendar based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_EventCalendar_DAO_EventCalendar|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_EventCalendar_DAO_EventCalendar';
-    $entityName = 'EventCalendar';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-    return $instance;
-  } */
 
 }


### PR DESCRIPTION
Civix used to generate commented-out BAO create functions, however all BAOs now inherit writeRecords() from their parent.

Since this function was never uncommented, it's safe to remove.